### PR TITLE
Return $null if index field is an array

### DIFF
--- a/lib/indexes.js
+++ b/lib/indexes.js
@@ -14,7 +14,7 @@ function checkValueEquality(a, b) {
  * Type-aware projection
  */
 function projectForUnique(elt) {
-  if (elt === null) {
+  if (elt === null || Array.isArray(elt)) {
     return '$null';
   }
   if (typeof elt === 'string') {


### PR DESCRIPTION
According to the docs, array fields are not supported for indexes. II had an error by adding an array as an index and then it's very hard to recover from it (`field.removeIndex(...)` will not work because the index is already stored in storage.

The easiest solution I can see is to return $null from the `projectForUnique` function when the indexed field is an array. At least, it worked for me. Cheers