### PR TITLE
Update typings.d.ts

### DIFF
--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -9,6 +9,7 @@ declare module 'react-native-local-mongodb' {
     beforeDeserialization?: Function;
     corruptAlertThreshold?: number;
     compareStrings?: Function;
+    storage: AsyncStorageStatic;
   }
 
   export interface IndexOptions {


### PR DESCRIPTION
Accept AsyncStorage as storage when to use Typescript. AsyncStorage from react-native core will be removed on the next version and this lib use it as alternative.