### PR TITLE
Add TypeScript Generics to Datastore for Type-Safe Document Operations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare module "react-native-local-mongodb" {
     beforeDeserialization?: Function;
     corruptAlertThreshold?: number;
     compareStrings?: Function;
-    storage: StorageStatic;
+    storage: StorageStatic | AsyncStorageStatic;
   }
 
   export interface IndexOptions {
@@ -75,81 +75,81 @@ declare module "react-native-local-mongodb" {
   ) => void;
   export type RemoveCallback = (err: Error | null, numAffected: number) => void;
 
-  export default class Datastore {
+  export default class Datastore<T = MongoDocument> {
     constructor(options?: Options);
-
+  
     public loadDatabase(): void;
-
-    public getAllData(): any[];
-
-    public resetIndexes(newData: any): void;
-
+  
+    public getAllData(): T[];
+  
+    public resetIndexes(newData: T[]): void;
+  
     public ensureIndex(options: IndexOptions, callback?: Callback): void;
-
+  
     public removeIndex(fieldName: string, callback?: Callback): void;
-
-    public addToIndexes(doc: MongoDocument): void;
-
-    public removeFromIndexes(doc: MongoDocument): void;
-
-    public updateIndexes(oldDoc: MongoDocument, newDoc: MongoDocument): void;
-
+  
+    public addToIndexes(doc: T): void;
+  
+    public removeFromIndexes(doc: T): void;
+  
+    public updateIndexes(oldDoc: T, newDoc: T): void;
+  
     public getCandidates(
       query: Query,
       dontExpireStaleDocs: boolean,
       callback?: Callback
     ): void;
-
-    public insert(newDoc: MongoDocument, cb: InsertCallback): void;
-
+  
+    public insert(newDoc: T, cb: InsertCallback): void;
+  
     public createNewId(): number;
-
+  
     public count(query: Query): Cursor<number>;
     public count(query: Query, callback: Callback<number>): void;
-
-    public find(query: Query): Cursor<MongoDocument[]>;
-    public find(query: Query, projection: Projection): Cursor<MongoDocument[]>;
+  
+    public find(query: Query): Cursor<T[]>;
+    public find(query: Query, projection: Projection): Cursor<T[]>;
     public find(
       query: Query,
       projection: Projection,
-      callback: Callback<MongoDocument[]>
+      callback: Callback<T[]>
     ): void;
-
-    public findOne(query: Query): Cursor<MongoDocument>;
-    public findOne(query: Query, projection: Projection): Cursor<MongoDocument>;
+  
+    public findOne(query: Query): Cursor<T>;
+    public findOne(query: Query, projection: Projection): Cursor<T>;
     public findOne(
       query: Query,
       projection: Projection,
-      callback: Callback<MongoDocument>
+      callback: Callback<T>
     ): void;
-
+  
     public update(
       query: Query,
-      doc: MongoDocument,
+      doc: T,
       options?: UpdateOptions,
       callback?: UpdateCallback
     ): void;
-
+  
     public remove(
       query: Query,
       options?: RemoveOptions,
       callback?: RemoveCallback
     ): void;
-
+  
     public loadDatabaseAsync(): Promise<void>;
-
-    public findAsync(query: Query): Promise<MongoDocument[]>;
-
-    public findOneAsync(query: Query): Promise<MongoDocument>;
-
-    public insertAsync(newDoc: MongoDocument): Promise<MongoDocument>;
-
+  
+    public findAsync(query: Query): Promise<T[]>;
+  
+    public findOneAsync(query: Query): Promise<T>;
+  
+    public insertAsync(newDoc: T): Promise<T>;
+  
     public updateAsync(
       query: Query,
-      doc: MongoDocument,
+      doc: T,
       options?: UpdateOptions
-    ): Promise<MongoDocument>;
-
+    ): Promise<T>;
+  
     public removeAsync(query: Query, options?: RemoveOptions): Promise<number>;
-  }
+  }  
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -148,7 +148,7 @@ declare module "react-native-local-mongodb" {
       query: Query,
       doc: T,
       options?: UpdateOptions
-    ): Promise<T>;
+    ): Promise<number>;
   
     public removeAsync(query: Query, options?: RemoveOptions): Promise<number>;
   }  


### PR DESCRIPTION
This PR refactors the Datastore class in react-native-local-mongodb to support TypeScript generics, providing type safety for document operations. The key changes include:

The Datastore class is now generic, allowing users to specify the document type (T) when instantiating a datastore. This ensures that document operations such as insert, find, update, and remove are type-safe and adhere to the structure defined by the user. Default type for the generic T is set to MongoDocument, maintaining backward compatibility for cases where a document type is not explicitly provided. Updated methods like insertAsync, findAsync, updateAsync, removeAsync, etc. to use the generic T instead of the default MongoDocument, improving type inference and code completion in TypeScript. Benefits: This change enforces type safety for documents stored in the datastore, reducing potential runtime errors. It provides better code completion and static analysis, helping developers catch type errors earlier during development. The update maintains backward compatibility by defaulting to MongoDocument if no type is specified.

How to Test: Instantiate a datastore with a specific type for documents (for example, Workout). Perform document operations like insertAsync, findAsync, and updateAsync to verify that TypeScript enforces the correct structure for the documents. Ensure that existing usages of the Datastore class without generics still work as expected.

```
const workoutDb = new Datastore<Workout>();
```

No breaking changes expected, and existing functionality remains intact with improved type safety.